### PR TITLE
Issues 44 45

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ myTeamsMessage.addPotentialAction(myTeamsPotentialAction1)
 myTeamsMessage.addPotentialAction(myTeamsPotentialAction2)
 myTeamsMessage.addPotentialAction(myTeamsPotentialAction3)
 
+hdrs = [ { 'name': 'X-Api-Key', 'value': 'key-you-need-from-teams' } ]
+myTeamsMessage.addRawPotentialAction("HttpPOST", "Click Me", "https://...", _headers=hdrs, _body='{ "a": "This is http POST json body"}')
+
 myTeamsMessage.summary("Test Message")
 
 myTeamsMessage.send()

--- a/pymsteams/__init__.py
+++ b/pymsteams/__init__.py
@@ -102,7 +102,7 @@ class potentialaction:
 
         self.payload["inputs"].append(input)
 
-    def addAction(self,_type,_name,_target):
+    def addAction(self,_type,_name,_target,_headers=None,_body=None):
         if "actions" not in self.payload.keys():
             self.payload["actions"] = []
         action = {
@@ -111,9 +111,14 @@ class potentialaction:
              "target": _target
         }
 
+        if _type.lower() == 'httppost':
+            if _headers:
+                action["headers"] = _headers
+            if _body:
+                action["body"] = _body
+
         self.payload["actions"].append(action)
 
-   
 
     def dumpPotentialAction(self):
         return self.payload

--- a/pymsteams/__init__.py
+++ b/pymsteams/__init__.py
@@ -188,6 +188,25 @@ class connectorcard:
 
         self.payload["potentialAction"].append(newaction.dumpPotentialAction())
 
+    def addRawPotentialAction(self,_type,_name,_target,_headers=None,_body=None):
+        # this function expects a potential action object
+        if "potentialAction" not in self.payload.keys():
+            self.payload["potentialAction"] = []
+
+        action = {
+            "@type": _type,
+             "name": _name,
+             "target": _target,
+        }
+
+        if _type.lower() == 'httppost':
+            if _headers:
+                action["headers"] = _headers
+            if _body:
+                action["body"] = _body
+
+        self.payload["potentialAction"].append(action)
+
     def printme(self):
         print("hookurl: %s" % self.hookurl)
         print("payload: %s" % self.payload)


### PR DESCRIPTION
This is related to issues  44/45. First commit adds optional _headers and _body parameters to addAction. (AFAIK these are relevant only for HttpPost action (https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#httppost-action)).

Second commit adds addRawPotentialAction that adds potentialaction without actioncard/inputs. See for example https://messagecardplayground.azurewebsites.net/ and "Github - Issue opened" sample ("close" button). (This is an action where you can click on the button and msteams does POST straight away without showing any more buttons/actions).