### PR TITLE
Upgrade requests to the newest version supporting urllib3 1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ myTeamsMessage.send()
 last_status_code = myTeamsMessage.last_http_status.status_code
 ```
 
-More info on the Repsponse Conent is available in the requests documentation, [link](https://2.python-requests.org/en/master/user/quickstart/#response-content).
+More info on the Response Content is available in the requests documentation, [link](https://2.python-requests.org/en/master/user/quickstart/#response-content).
 
 ## Exceptions
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -32,7 +32,7 @@ pyparsing==2.4.0
 pytest==5.0.1
 PyYAML==5.4
 readme-renderer==26.0
-requests==2.23.0
+requests==2.25.1
 requests-toolbelt==0.9.1
 safety==1.9.0
 SecretStorage==3.1.2


### PR DESCRIPTION
Fixes failing tests after merging #98 and some typos in README.