### PR TITLE
publish wheels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           paths:
             - ./venv
           key: v1-dependencies-{{ checksum "dev-requirements.txt" }}
-        
+
   test:
     docker:
       - image: circleci/python:3
@@ -52,8 +52,8 @@ jobs:
             python -m pip install --upgrade pip
             pip install -r dev-requirements.txt
             pytest -v --junitxml=/tmp/pytest/results.xml >> /tmp/test-reports/pytest.out
-            
-            
+
+
 
       - store_artifacts:
           path: /tmp/test-reports
@@ -84,11 +84,11 @@ jobs:
             python -m pip install --upgrade pip
             python setup.py verify
 
-      - run: 
+      - run:
           name: make a source distribution
           command: |
             . venv/bin/activate
-            python setup.py sdist
+            python -m build
 
       - run:
           name: upload to pypi

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 bandit
+build
 httpx
 pytest
 pytest-cov


### PR DESCRIPTION
I notice that this project only publishes source distributions.  This forces every consumer to build the wheel themselves: which is slower and might even go wrong. 

Better for package owners to build and publish their wheel once and for all